### PR TITLE
[Android] Sometimes the returned address contains 'null'

### DIFF
--- a/src/android/CDVGeocoder.java
+++ b/src/android/CDVGeocoder.java
@@ -102,10 +102,33 @@ public class CDVGeocoder extends CordovaPlugin {
 
 		coords.put("latitude", addr.getLatitude());
 		coords.put("longitude", addr.getLongitude());
-		coords.put("address", addr.getAddressLine(0) +" "+ addr.getAddressLine(1)+" "+addr.getAddressLine(2));
 
-		//System.out.print(coords);
+        String addressStr = getAddressAsString(addr);
+        if (addressStr != null) {
+            coords.put("address", addressStr);
+        }
 
-		return coords;
-	}
+        return coords;
+    }
+
+    private String getAddressAsString(Address addr) {
+
+        String addressStr = null;
+
+        int i = addr.getMaxAddressLineIndex();
+
+        if (i >= 0) {
+            addressStr = addr.getAddressLine(0);
+
+            int j = 1;
+
+            while (j <= i) {
+                addressStr += ", ";
+                addressStr += addr.getAddressLine(j);
+                j++;
+            }
+
+        }
+        return addressStr;
+    }
 }


### PR DESCRIPTION
To prevent this i just used MaxAddressLineIndex to get maximum adresse lines (and thus not limiting to 3 the address lines).
